### PR TITLE
Improve networking decode failure logging

### DIFF
--- a/Submodules/Sources/InfrastructureLayer/Networking/RequestType.swift
+++ b/Submodules/Sources/InfrastructureLayer/Networking/RequestType.swift
@@ -15,11 +15,16 @@ public extension RequestTypeProtocol {
     func execute(on router: NetworkRouterProtocol) async throws -> Any {
         let data = try await router.request(request)
         
-        if let responseData = data, // String(data: data!, encoding: .utf8)
-           let decodedData = try? JSONDecoder().decode(ResponseType.self, from: responseData) {
-            return decodedData
+        guard let responseData = data else {
+            throw RequestError.badlyFormattedResponse
+        }
 
-        } else {
+        do {
+            return try JSONDecoder().decode(ResponseType.self, from: responseData)
+        } catch {
+            let responseString = String(data: responseData, encoding: .utf8) ?? "<non-utf8 response>"
+            print("Decoding failed for \(ResponseType.self). Response body:")
+            print(responseString)
             throw RequestError.badlyFormattedResponse
         }
     }


### PR DESCRIPTION
### Motivation
- Network response parsing started failing and the intent is to surface the raw response body when JSON decoding fails so the root cause can be diagnosed quickly.

### Description
- Updated `RequestTypeProtocol.execute(on:)` to explicitly guard that `Data` is present before decoding. 
- Replaced the conditional `try? JSONDecoder().decode` with an explicit `do`/`catch` that attempts `JSONDecoder().decode(ResponseType.self, from: responseData)` and rethrows a `RequestError.badlyFormattedResponse` on failure. 
- On decode failure the code now logs the response body (or `"<non-utf8 response>"` when it cannot be represented as UTF-8) to aid debugging. 
- Change applied to `Submodules/Sources/InfrastructureLayer/Networking/RequestType.swift`.

### Testing
- No automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984f17b73f88326afcdc6b52288a3c6)